### PR TITLE
Parallel processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ The wind resource analysis requires ERA5 wind and geopotential data which can be
 requires an [CDS account](https://cds.climate.copernicus.eu/user/register) and
 [installing the CDS API key](https://cds.climate.copernicus.eu/api-how-to).
 Furthermore, it is required to accept the terms and conditions for using the ERA5 data. The command below can be used to
-start downloading the wind dataset for the requested year (make sure that the new virtual environment is active). This
-command should be executed manually for each year of data that you want to download. The size of 1 year of wind data for
+start downloading the wind dataset for the requested year (make sure that the new virtual environment is active). The size of 1 year of wind data for
 Western and Central Europe, as used in the paper, is roughly 2 GB. Make sure that there is sufficient disk
 space available, that you point the parameter era5_data_dir in the config.py file to the correct location and that you download all the years of data as specified in config.py. Note that the downloading is time
 costly, in the order of magnitude of days. It is important to prevent your machine from going into sleep mode while the downloading. The

--- a/config.py
+++ b/config.py
@@ -36,5 +36,5 @@ area = "65/-20/30/20"
 upper_level = 112
 
 # Processing settings.
-output_file_name = "results/processed_data_{:d}_{:d}.nc".format(start_year, final_year)
+output_file_name = "/cephfs/user/s6lathim/ERA5Data-112/results/processed_data_europe_{:d}_{:d}_subset_{}_of_{}.nc"#.format(start_year, final_year, subset_index, maximal_subset_index)
 read_n_lats_at_once = 1

--- a/config.py
+++ b/config.py
@@ -36,5 +36,7 @@ area = "65/-20/30/20"
 upper_level = 112
 
 # Processing settings.
-output_file_name = "results/processed_data_europe_{start_year:d}_{final_year:d}_subset_{lat_subset_id:04d}_of_{max_lat_subset_id:04d}.nc"
+output_file_name = "results/processed_data_europe_{start_year:d}_{final_year:d}.nc"
+output_file_name_subset = "results/processed_data_europe_{start_year:d}_{final_year:d}_subset_{lat_subset_id:04d}_of_{max_lat_subset_id:04d}.nc"
+
 read_n_lats_per_subset = 1

--- a/config.py
+++ b/config.py
@@ -37,4 +37,4 @@ upper_level = 112
 
 # Processing settings.
 output_file_name = "results/processed_data_europe_{start_year:d}_{final_year:d}_subset_{lat_subset_id:04d}_of_{max_lat_subset_id:04d}.nc"
-read_n_lats_at_once = 1
+read_n_lats_per_subset = 1

--- a/config.py
+++ b/config.py
@@ -33,7 +33,7 @@ surface_file_name_format = 'sfc_{:d}_{:02d}.netcdf'  #"{:d}_europe_{:d}_152.nc"
 
 # Downloading settings.
 area = "65/-20/30/20"
-upper_level = 122
+upper_level = 112
 
 # Processing settings.
 output_file_name = "results/processed_data_{:d}_{:d}.nc".format(start_year, final_year)

--- a/config.py
+++ b/config.py
@@ -36,5 +36,5 @@ area = "65/-20/30/20"
 upper_level = 112
 
 # Processing settings.
-output_file_name = "/cephfs/user/s6lathim/ERA5Data-112/results/processed_data_europe_{:d}_{:d}_subset_{}_of_{}.nc"#.format(start_year, final_year, subset_index, maximal_subset_index)
+output_file_name = "/cephfs/user/s6lathim/ERA5Data-112/results/processed_data_europe_{start_year:d}_{final_year:d}_subset_{lat_subset_id:04d}_of_{max_lat_subset_id:04d}.nc"
 read_n_lats_at_once = 1

--- a/config.py
+++ b/config.py
@@ -36,5 +36,5 @@ area = "65/-20/30/20"
 upper_level = 112
 
 # Processing settings.
-output_file_name = "/cephfs/user/s6lathim/ERA5Data-112/results/processed_data_europe_{start_year:d}_{final_year:d}_subset_{lat_subset_id:04d}_of_{max_lat_subset_id:04d}.nc"
+output_file_name = "results/processed_data_europe_{start_year:d}_{final_year:d}_subset_{lat_subset_id:04d}_of_{max_lat_subset_id:04d}.nc"
 read_n_lats_at_once = 1

--- a/plot_maps.py
+++ b/plot_maps.py
@@ -4,7 +4,7 @@
 
 Example::
 
-    $ python plot_maps.py              : plot from files with maximal subset id of the preset value
+    $ python plot_maps.py -c           : plot from files from combined output file
     $ python plot_maps.py -m max_id    : plot from files with maximal subset id of max_id
     $ python plot_maps.py -h           : display this help
 
@@ -35,37 +35,8 @@ n_fill_levels_default = 14
 n_line_levels_default = 6
 color_map = cm.YlOrRd
 
-# Load the processed data from the NetCDF file.
-help = """
-    python plot_maps.py -c           : plot from files from combined output file
-    python plot_maps.py -m max_id    : plot from files with maximal subset id of max_id
-    python plot_maps.py -h           : display this help
-    """.format(max_subset_id)
-
-if len(sys.argv) > 1: 
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], "hm:c", ["help", "maxid=", "combined"])
-    except getopt.GetoptError:     # User input not given correctly, display help and end
-        print(help)
-        sys.exit()
-    for opt, arg in opts:
-        if opt in ("-h", "--help"):    # Help argument called, display help and end
-            print (help)
-            sys.exit()
-        elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
-            max_subset_id = int(arg)
-            # find all subset files matching the settings in config.py - including all until max_subset_id 
-            all_year_subset_files = [output_file_name_subset.format(**{'start_year':start_year, 'final_year':final_year,\
-                'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
-            print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year,\
-                final_year, max_subset_id))
-            nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
-        elif opt in ("-c", "--combined"):     # User Input to use combined file
-            file_name = output_file_name.format(**{'start_year':start_year, 'final_year':final_year})
-            nc = xr.open_dataset(file_name)
-else:
-    print(help)
-
+# Load the processed data from the NetCDF files specified in the input.
+nc = read_dataset_user_input()
 
 lons = nc['longitude'].values
 lats = nc['latitude'].values
@@ -85,6 +56,46 @@ map_plot = Basemap(projection='merc', llcrnrlon=np.min(lons), llcrnrlat=np.min(l
                    urcrnrlat=np.max(lats), resolution=map_resolution)
 x_grid, y_grid = map_plot(lons_grid, lats_grid)  # Compute map projection coordinates.
 map_plot_aspect_ratio = 9. / 12.3  # Aspect ratio of Europe map.
+
+def read_dataset_user_input():
+    """"Interpret user input to open the dataset(s)
+
+    Returns:
+        nc (Dataset): Plotting input data (from processing)
+    """
+
+    help = """
+        python plot_maps.py -c           : plot from files from combined output file
+        python plot_maps.py -m max_id    : plot from files with maximal subset id of max_id
+        python plot_maps.py -h           : display this help
+        """
+
+    if len(sys.argv) > 1: 
+        try:
+            opts, args = getopt.getopt(sys.argv[1:], "hm:c", ["help", "maxid=", "combined"])
+        except getopt.GetoptError:     # User input not given correctly, display help and end
+            print(help)
+            sys.exit()
+        for opt, arg in opts:
+            if opt in ("-h", "--help"):    # Help argument called, display help and end
+                print (help)
+                sys.exit()
+            elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
+                max_subset_id = int(arg)
+                # find all subset files matching the settings in config.py - including all until max_subset_id 
+                all_year_subset_files = [output_file_name_subset.format(**{'start_year':start_year, 'final_year':final_year,\
+                    'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
+                print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year,\
+                    final_year, max_subset_id))
+                nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
+            elif opt in ("-c", "--combined"):     # User Input to use combined file
+                file_name = output_file_name.format(**{'start_year':start_year, 'final_year':final_year})
+                nc = xr.open_dataset(file_name)
+    else:
+        print(help)
+        sys.exit()
+
+    return nc
 
 
 def calc_fig_height(fig_width, subplot_shape, plot_frame_top, plot_frame_bottom, plot_frame_left, plot_frame_right):

--- a/plot_maps.py
+++ b/plot_maps.py
@@ -19,11 +19,12 @@ from matplotlib.cbook import MatplotlibDeprecationWarning
 from mpl_toolkits.basemap import Basemap
 import warnings
 
+import sys, getopt
+import os
+
 from utils import hour_to_date_str
 from config import output_file_name, start_year, final_year
 
-import sys, getopt
-import os
 
 warnings.filterwarnings("ignore", category=MatplotlibDeprecationWarning)
 

--- a/plot_maps.py
+++ b/plot_maps.py
@@ -23,6 +23,7 @@ import sys, getopt
 import os
 
 from utils import hour_to_date_str
+from plotting_utils import read_dataset_user_input
 from config import output_file_name, output_file_name_subset, start_year, final_year
 
 
@@ -57,45 +58,6 @@ map_plot = Basemap(projection='merc', llcrnrlon=np.min(lons), llcrnrlat=np.min(l
 x_grid, y_grid = map_plot(lons_grid, lats_grid)  # Compute map projection coordinates.
 map_plot_aspect_ratio = 9. / 12.3  # Aspect ratio of Europe map.
 
-def read_dataset_user_input():
-    """"Interpret user input to open the dataset(s)
-
-    Returns:
-        nc (Dataset): Plotting input data (from processing)
-    """
-
-    help = """
-        python plot_maps.py -c           : plot from files from combined output file
-        python plot_maps.py -m max_id    : plot from files with maximal subset id of max_id
-        python plot_maps.py -h           : display this help
-        """
-
-    if len(sys.argv) > 1: 
-        try:
-            opts, args = getopt.getopt(sys.argv[1:], "hm:c", ["help", "maxid=", "combined"])
-        except getopt.GetoptError:     # User input not given correctly, display help and end
-            print(help)
-            sys.exit()
-        for opt, arg in opts:
-            if opt in ("-h", "--help"):    # Help argument called, display help and end
-                print (help)
-                sys.exit()
-            elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
-                max_subset_id = int(arg)
-                # find all subset files matching the settings in config.py - including all until max_subset_id 
-                all_year_subset_files = [output_file_name_subset.format(**{'start_year':start_year, 'final_year':final_year,\
-                    'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
-                print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year,\
-                    final_year, max_subset_id))
-                nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
-            elif opt in ("-c", "--combined"):     # User Input to use combined file
-                file_name = output_file_name.format(**{'start_year':start_year, 'final_year':final_year})
-                nc = xr.open_dataset(file_name)
-    else:
-        print(help)
-        sys.exit()
-
-    return nc
 
 
 def calc_fig_height(fig_width, subplot_shape, plot_frame_top, plot_frame_bottom, plot_frame_left, plot_frame_right):

--- a/plot_maps.py
+++ b/plot_maps.py
@@ -35,18 +35,15 @@ n_line_levels_default = 6
 color_map = cm.YlOrRd
 
 # Load the processed data from the NetCDF file.
-
-# find all subset files matching the settings in config.py - including all until max_subset_id 
-max_subset_id = 35
-#change max_subset_id if user input is given:
-if len(sys.argv) > 1: 
-    help = """
-    python plot_maps.py              : plot from files with maximal subset id of {}
+help = """
+    python plot_maps.py -c           : plot from files from combined output file
     python plot_maps.py -m max_id    : plot from files with maximal subset id of max_id
     python plot_maps.py -h           : display this help
     """.format(max_subset_id)
+
+if len(sys.argv) > 1: 
     try:
-        opts, args = getopt.getopt(sys.argv[1:], "hm:", ["help", "maxid="])
+        opts, args = getopt.getopt(sys.argv[1:], "hm:c", ["help", "maxid=", "combined"])
     except getopt.GetoptError:     # User input not given correctly, display help and end
         print(help)
         sys.exit()
@@ -56,11 +53,18 @@ if len(sys.argv) > 1:
             sys.exit()
         elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
             max_subset_id = int(arg)
-
-all_year_subset_files = [output_file_name.format(**{'start_year':start_year, 'final_year':final_year, 'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
-
-print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year, final_year, max_subset_id))
-nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
+            # find all subset files matching the settings in config.py - including all until max_subset_id 
+            all_year_subset_files = [output_file_name.format(**{'start_year':start_year, 'final_year':final_year,\
+                'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
+            print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year,\
+                final_year, max_subset_id))
+            nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
+        elif opt in ("-c", "--combined"):     # User Input to use combined file
+            file_name = output_file_name.split('subset')[0]+'all_subsets.nc').format(**{'start_year':start_year,\
+                'final_year':final_year})
+            nc = xr.open_dataset(file_name)
+else:
+    print(help)
 
 
 lons = nc['longitude'].values

--- a/plot_maps.py
+++ b/plot_maps.py
@@ -23,7 +23,7 @@ import sys, getopt
 import os
 
 from utils import hour_to_date_str
-from config import output_file_name, start_year, final_year
+from config import output_file_name, output_file_name_subset, start_year, final_year
 
 
 warnings.filterwarnings("ignore", category=MatplotlibDeprecationWarning)
@@ -55,14 +55,13 @@ if len(sys.argv) > 1:
         elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
             max_subset_id = int(arg)
             # find all subset files matching the settings in config.py - including all until max_subset_id 
-            all_year_subset_files = [output_file_name.format(**{'start_year':start_year, 'final_year':final_year,\
+            all_year_subset_files = [output_file_name_subset.format(**{'start_year':start_year, 'final_year':final_year,\
                 'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
             print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year,\
                 final_year, max_subset_id))
             nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
         elif opt in ("-c", "--combined"):     # User Input to use combined file
-            file_name = output_file_name.split('subset')[0]+'all_subsets.nc').format(**{'start_year':start_year,\
-                'final_year':final_year})
+            file_name = output_file_name.format(**{'start_year':start_year, 'final_year':final_year})
             nc = xr.open_dataset(file_name)
 else:
     print(help)

--- a/plot_maps.py
+++ b/plot_maps.py
@@ -57,9 +57,9 @@ if len(sys.argv) > 1:
         elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
             max_subset_id = int(arg)
 
-all_year_subset_files = [output_file_name.format(start_year, final_year, subset_id, max_subset_id) for subset_id in range(max_subset_id +1)]
+all_year_subset_files = [output_file_name.format(**{'start_year':start_year, 'final_year':final_year, 'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
 
-print('All data for the years {} to {} is read from subset_files from 0 to {}',format(start_year, end_year, max_subset_id)
+print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year, final_year, max_subset_id))
 nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
 
 

--- a/plotting_utils.py
+++ b/plotting_utils.py
@@ -1,0 +1,47 @@
+import xarray as xr
+import sys, getopt
+import os
+
+from config import output_file_name, output_file_name_subset, start_year, final_year
+
+
+def read_dataset_user_input():
+    """"Interpret user input to open the dataset(s)
+
+    Returns:
+        nc (Dataset): Plotting input data (from processing)
+    """
+
+    help = """
+        python plot_maps.py -c           : plot from files from combined output file
+        python plot_maps.py -m max_id    : plot from files with maximal subset id of max_id
+        python plot_maps.py -h           : display this help
+        """
+
+    if len(sys.argv) > 1: 
+        try:
+            opts, args = getopt.getopt(sys.argv[1:], "hm:c", ["help", "maxid=", "combined"])
+        except getopt.GetoptError:     # User input not given correctly, display help and end
+            print(help)
+            sys.exit()
+        for opt, arg in opts:
+            if opt in ("-h", "--help"):    # Help argument called, display help and end
+                print (help)
+                sys.exit()
+            elif opt in ("-m", "--maxid"):     # User Input maximal subset id given  
+                max_subset_id = int(arg)
+                # find all subset files matching the settings in config.py - including all until max_subset_id 
+                all_year_subset_files = [output_file_name_subset.format(**{'start_year':start_year, 'final_year':final_year,\
+                    'lat_subset_id':subset_id, 'max_lat_subset_id':max_subset_id}) for subset_id in range(max_subset_id +1)]
+                print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year,\
+                    final_year, max_subset_id))
+                nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
+            elif opt in ("-c", "--combined"):     # User Input to use combined file
+                file_name = output_file_name.format(**{'start_year':start_year, 'final_year':final_year})
+                nc = xr.open_dataset(file_name)
+    else:
+        print(help)
+        sys.exit()
+
+    return nc
+

--- a/process_data.py
+++ b/process_data.py
@@ -241,7 +241,7 @@ def process_grid_subsets(output_file, input_subset_ids):
         # Initialize output and result arrays for this subset
         fixed_heights_out, height_range_ceilings_out, hours_out, integration_range_ids_out, lats_out, lons_out,\
               nc_out, output_variables = create_and_configure_output_netcdf(hours, lats_subset, lons, \
-              output_file.format(start_year, final_year, i_subset, n_subsets-1))
+              output_file.format(**{'start_year':start_year, 'final_year':final_year, 'lat_subset_id':i_subset, 'max_lat_subset_id':(n_subsets-1)}))
 
         res = initialize_result_arrays(lats_subset, lons)
 

--- a/process_data.py
+++ b/process_data.py
@@ -23,7 +23,7 @@ import dask
 
 from utils import hour_to_date_str, compute_level_heights
 from config import start_year, final_year, era5_data_dir, model_level_file_name_format, surface_file_name_format,\
-    output_file_name, read_n_lats_at_once
+    output_file_name, read_n_lats_per_subset
 
 
 #only as many threads as requested CPUs | only one to be requested, more threads don't seem to be used
@@ -194,7 +194,7 @@ def get_subset_range_from_input(input_subset_ids, n_subsets):
     Args:
         input_subset_ids (list): Program arguments read to give a list of starting (and ending) subset
                                  IDs to be analyzed
-        n_subsets (int): number of latitude subsets determined by latitudes in data and read_n_lats_at_once
+        n_subsets (int): number of latitude subsets determined by latitudes in data and read_n_lats_per_subset
 
     Returns: 
         subset_range (list): subset IDs to be analyzed 
@@ -239,7 +239,7 @@ def process_grid_subsets(output_file, input_subset_ids):
     # Reading the data of all grid points from the NetCDF file all at once requires a lot of memory. On the other hand,
     # reading the data of all grid points one by one takes up a lot of CPU. Therefore, the dataset is analysed in
     # pieces: the subsets are read and processed consecutively.
-    n_subsets = int(np.ceil(float(len(lats)) / read_n_lats_at_once))
+    n_subsets = int(np.ceil(float(len(lats)) / read_n_lats_per_subset))
 
     # Choose subsets to be processed in this run
     subset_range = get_subset_range_from_input(input_subset_ids, n_subsets)
@@ -251,9 +251,9 @@ def process_grid_subsets(output_file, input_subset_ids):
 
     for i_subset in subset_range:
         # Find latitudes corresponding to the current i_subset
-        i_lat0 = i_subset * read_n_lats_at_once
-        if i_lat0+read_n_lats_at_once < len(lats):
-            lat_ids_subset = range(i_lat0, i_lat0 + read_n_lats_at_once)
+        i_lat0 = i_subset * read_n_lats_per_subset
+        if i_lat0+read_n_lats_per_subset < len(lats):
+            lat_ids_subset = range(i_lat0, i_lat0 + read_n_lats_per_subset)
         else:
             lat_ids_subset = range(i_lat0, len(lats))
         lats_subset = lats[lat_ids_subset]

--- a/process_data.py
+++ b/process_data.py
@@ -566,8 +566,8 @@ if __name__ == '__main__':
                 input_start_subset_id = int(arg)
             elif opt in ("-e", "--end"):     # End of subset range indicated (inclusively) 
                 input_end_subset_id = int(arg)
-        if input_end_subset_id < input_start_subset_id:
-            raise ValueError("End subset id {} larger than start id {}, check given input".format(input_end_subset_id, input_start_subset_id))
+        if input_end_subset_id != -1 and input_end_subset_id < input_start_subset_id:
+            raise ValueError("End subset id {} smaller than start id {}, check given input".format(input_end_subset_id, input_start_subset_id))
             sys.exit() 
 
     # Start processing

--- a/process_data.py
+++ b/process_data.py
@@ -19,7 +19,7 @@ from utils import hour_to_date_str, compute_level_heights
 from config import start_year, final_year, era5_data_dir, model_level_file_name_format, surface_file_name_format,\
     output_file_name, read_n_lats_at_once
 
-# Set the relevant heights for the different analysis types.
+# Set the relevant heights for the different analysis types in meter.
 analyzed_heights = {
     'floor': 50.,
     'ceilings': [200., 300., 400., 500.],

--- a/process_data.py
+++ b/process_data.py
@@ -17,14 +17,16 @@ from timeit import default_timer as timer
 from scipy.stats import percentileofscore
 from os.path import join as path_join
 
+import sys, getopt
+
+import dask 
+
 from utils import hour_to_date_str, compute_level_heights
 from config import start_year, final_year, era5_data_dir, model_level_file_name_format, surface_file_name_format,\
     output_file_name, read_n_lats_at_once
 
-import sys, getopt
 
 #only as many threads as requested CPUs | only one to be requested, more threads don't seem to be used
-import dask 
 dask.config.set(scheduler='synchronous')
 
 # Set the relevant heights for the different analysis types in meter.
@@ -277,7 +279,7 @@ def process_grid_subsets(output_file, input_subset_ids):
 
         print('    Input read, performing satistical analysis now, time lapsed: {:.2f} hrs'.format(float(timer()-start_time)/3600))
 
-        for i_lat_in_subset in range(len(lat_ids_subset)):# All subsets are written out, always start at 0 for a new subset
+        for i_lat_in_subset in range(len(lat_ids_subset)):# Individual files saved for each subset, always start at idx 0
             for i_lon in range(len(lons)):
                 if (i_lon % 20) == 0:# Give processing info every 20 longitudes 
                     print('        {} of {} longitudes analyzed, satistical analysis of longitude {}, time lapsed: {:.2f} hrs'\
@@ -567,7 +569,7 @@ def eval_single_location(location_lat, location_lon, start_year, final_year):
 
 
 if __name__ == '__main__':
-    print("processing monthly ERA5 data from the years {:d} to {:d}".format(start_year, final_year))
+    print("processing monthly ERA5 data from {:d} to {:d}".format(start_year, final_year))
 
     # Read command-line arguments
     input_subset_ids = [] 
@@ -595,5 +597,5 @@ if __name__ == '__main__':
     # Start processing
     max_subset_id = process_grid_subsets(output_file_name, input_subset_ids)
 
-    if input_subset_ids == []: #All subsets processed at once, combine instantly
-        merge_output_files(start_year, final_year, 140)#max_subset_id)
+    if len(sys.argv) == 1: #No user input given - all subsets processed at once, combine instantly
+        merge_output_files(start_year, final_year, max_subset_id)

--- a/process_data.py
+++ b/process_data.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-"""Process wind data for adjacent years and save processed data to a NetCDF file. Settings, such as target file name,
+"""Process wind data for adjacent years and save processed data to a NetCDF file per subset. Settings, such as target file name,
 are imported from config.py.
 
 Example::
 
-    $ python process_data.py
+    $ python process_data.py                  : process all latitudes (all subsets)
+    $ python process_data.py -s subsetID      : process individual subset with ID subsetID
+    $ python process_data.py -s ID1 -e ID2    : process range of subsets starting at subset ID1 until ID2 (inclusively)
+    $ python process_data.py -h               : display this help
 
 """
 from netCDF4 import Dataset
@@ -19,10 +22,16 @@ from utils import hour_to_date_str, compute_level_heights
 from config import start_year, final_year, era5_data_dir, model_level_file_name_format, surface_file_name_format,\
     output_file_name, read_n_lats_at_once
 
+import sys, getopt
+
+#only as many threads as requested CPUs | only one to be requested, more threads don't seem to be used
+import dask 
+dask.config.set(scheduler='synchronous')
+
 # Set the relevant heights for the different analysis types in meter.
 analyzed_heights = {
     'floor': 50.,
-    'ceilings': [200., 300., 400., 500.],
+    'ceilings': [200., 300., 400., 500., 1000.],
     'fixed': [100.],
     'integration_ranges': [(50., 150.), (10., 500.)],
 }
@@ -120,7 +129,6 @@ def read_raw_data(start_year, final_year):
         for m in range(1, 13):
             ml_files.append(path_join(era5_data_dir, model_level_file_name_format.format(y, m)))
             sfc_files.append(path_join(era5_data_dir, surface_file_name_format.format(y, m)))
-
     # Load the data from the NetCDF files.
     ds = xr.open_mfdataset(ml_files+sfc_files, decode_times=False)
 
@@ -158,67 +166,121 @@ def check_for_missing_data(hours):
                                                         hour_to_date_str(hours[i+1])))
 
 
-def process_complete_grid(output_file):
+def get_subset_range_from_input(input_subset_ids, n_subsets):
+    """"Interpret the input subset IDs with the read number of subsets available to 
+        find the subset IDs to be analyzed.
+
+    Args:
+        input_subset_ids (list): Program arguments read to give a list of starting (and ending) subset
+                                 IDs to be analyzed
+        n_subsets (int): number of latitude subsets determined by latitudes in data and read_n_lats_at_once
+
+    Returns: 
+        subset_range (list): subset IDs to be analyzed 
+    """
+    if len(input_subset_ids) == 1:
+        if input_subset_ids[0] < n_subsets:
+            # Only one ID given, thus only the corresponding subset is processed
+            subset_range = range(input_subset_ids[0], input_subset_ids[0]+1)
+            print("Only one latitude subset is analyzed, with subset ID {}".format(subset_range[0]))
+
+        else:
+            raise ValueError("Requested subset ID ({}) is higher than maximal subset ID {}."
+                .format(input_subset_ids[0], (n_subsets-1)))
+    elif len(input_subset_ids) == 2:
+        if all(ids < n_subsets for ids in input_subset_ids):
+            # Starting and ending ID of subsets given, the inclusive range is processed  
+            subset_range = range(input_subset_ids[0], input_subset_ids[1]+1)
+            print("A range of latitude subsets is analyzed, including subset ID {} to {}".format(subset_range[0], subset_range[-1]))
+        else:
+            raise ValueError("One of the requested subset IDs ({}, {}) is higher than maximal subset ID {}."
+                .format(input_subset_ids[0], input_subset_ids[1], (n_subsets-1)))
+    else:
+        subset_range = range(n_subsets)
+        print("All {} subsets are analyzed".format(n_subsets))
+
+    return subset_range
+
+
+def process_grid_subsets(output_file, input_subset_ids):
     """"Execute analyses on the data of the complete grid and save the processed data to a netCDF file.
 
     Args:
-        output_file (str): Name of netCDF file to which the results are saved.
+        output_file (str): Name of netCDF file to which the results are saved for the respective 
+                           subset. (including format {} placeholders)
+        input_subset_ids (list): 
 
     """
     ds, lons, lats, levels, hours, i_highest_level = read_raw_data(start_year, final_year)
     check_for_missing_data(hours)
 
-    fixed_heights_out, height_range_ceilings_out, hours_out, integration_range_ids_out, lats_out, lons_out, nc_out, output_variables = create_and_configure_output_netcdf(
-        hours, lats, lons, output_file)
-
-    res = initialize_result_arrays(lats, lons)
-
-    # Write data corresponding to the dimensions to the output file.
-    hours_out[:] = hours
-    lats_out[:] = lats
-    lons_out[:] = lons
-
-    height_range_ceilings_out[:] = analyzed_heights['ceilings']
-    fixed_heights_out[:] = analyzed_heights['fixed']
-    integration_range_ids_out[:] = integration_range_ids
-
-    # Loop over all locations to write processed data to the output file.
-    counter = 0
-    total_iters = len(lats) * len(lons)
-    start_time = timer()
 
     # Reading the data of all grid points from the NetCDF file all at once requires a lot of memory. On the other hand,
     # reading the data of all grid points one by one takes up a lot of CPU. Therefore, the dataset is analysed in
     # pieces: the subsets are read and processed consecutively.
     n_subsets = int(np.ceil(float(len(lats)) / read_n_lats_at_once))
 
-    for i_subset in range(n_subsets):
+    # Choose subsets to be processed in this run
+    subset_range = get_subset_range_from_input(input_subset_ids, n_subsets)
+    
+    # Loop over all specified subsets to write processed data to the output file.
+    counter = 0
+    total_iters = len(lats) * len(lons)*len(subset_range)/n_subsets
+    start_time = timer()
+
+    for i_subset in subset_range:
+        # Find latitudes corresponding to the current i_subset
         i_lat0 = i_subset * read_n_lats_at_once
         if i_lat0+read_n_lats_at_once < len(lats):
-            lats_subset = range(i_lat0, i_lat0 + read_n_lats_at_once)
+            lat_ids_subset = range(i_lat0, i_lat0 + read_n_lats_at_once)
         else:
-            lats_subset = range(i_lat0, len(lats))
+            lat_ids_subset = range(i_lat0, len(lats))
+        lats_subset = lats[lat_ids_subset]
+        print("Subset {}, Latitude(s) analysed: {} to {}".format(i_subset, lats_subset[0], lats_subset[-1]))
 
-        v_levels_east = ds.variables['u'][:, i_highest_level:, lats_subset, :].values
-        v_levels_north = ds.variables['v'][:, i_highest_level:, lats_subset, :].values
+        # Initialize output and result arrays for this subset
+        fixed_heights_out, height_range_ceilings_out, hours_out, integration_range_ids_out, lats_out, lons_out,\
+              nc_out, output_variables = create_and_configure_output_netcdf(hours, lats_subset, lons, \
+              output_file.format(start_year, final_year, i_subset, n_subsets-1))
+
+        res = initialize_result_arrays(lats_subset, lons)
+
+        # Write data corresponding to the dimensions to the output file.
+        hours_out[:] = hours
+        lats_out[:] = lats_subset
+        lons_out[:] = lons
+
+        height_range_ceilings_out[:] = analyzed_heights['ceilings']
+        fixed_heights_out[:] = analyzed_heights['fixed']
+        integration_range_ids_out[:] = integration_range_ids
+
+        print('    Output configured, reading subset input now, time lapsed: {:.2f} hrs'.format(float(timer()-start_time)/3600))
+
+        # Read data for the subset latitudes  
+        v_levels_east = ds.variables['u'][:, i_highest_level:, lat_ids_subset, :].values
+        v_levels_north = ds.variables['v'][:, i_highest_level:, lat_ids_subset, :].values
         v_levels = (v_levels_east**2 + v_levels_north**2)**.5
 
-        t_levels = ds.variables['t'][:, i_highest_level:, lats_subset, :].values
-        q_levels = ds.variables['q'][:, i_highest_level:, lats_subset, :].values
+        t_levels = ds.variables['t'][:, i_highest_level:, lat_ids_subset, :].values
+        q_levels = ds.variables['q'][:, i_highest_level:, lat_ids_subset, :].values
 
         try:
-            surface_pressure = ds.variables['sp'][:, lats_subset, :].values
+            surface_pressure = ds.variables['sp'][:, lat_ids_subset, :].values
         except KeyError:
-            surface_pressure = np.exp(ds.variables['lnsp'][:, lats_subset, :].values)
+            surface_pressure = np.exp(ds.variables['lnsp'][:, lat_ids_subset, :].values)
 
-        for row_in_v_levels, i_lat in enumerate(lats_subset):
+        print('    Input read, performing satistical analysis now, time lapsed: {:.2f} hrs'.format(float(timer()-start_time)/3600))
+
+        for i_lat_in_subset in range(len(lat_ids_subset)):# All subsets are written out, always start at 0 for a new subset
             for i_lon in range(len(lons)):
+                if (i_lon % 20) == 0:# Give processing info every 20 longitudes 
+                    print('        {} of {} longitudes analyzed, satistical analysis of longitude {}, time lapsed: {:.2f} hrs'\
+                         .format(i_lon, len(lons), lons[i_lon], float(timer()-start_time)/3600))
                 counter += 1
                 level_heights, density_levels = compute_level_heights(levels,
-                                                                      surface_pressure[:, row_in_v_levels, i_lon],
-                                                                      t_levels[:, :, row_in_v_levels, i_lon],
-                                                                      q_levels[:, :, row_in_v_levels, i_lon])
-
+                                                                      surface_pressure[:, i_lat_in_subset, i_lon],
+                                                                      t_levels[:, :, i_lat_in_subset, i_lon],
+                                                                      q_levels[:, :, i_lat_in_subset, i_lon])
                 # Determine wind at altitudes of interest by means of interpolating the raw wind data.
                 v_req_alt = np.zeros((len(hours), len(heights_of_interest)))  # result array for writing interpolated data
                 rho_req_alt = np.zeros((len(hours), len(heights_of_interest)))
@@ -228,7 +290,7 @@ def process_complete_grid(output_file):
                         raise ValueError("Requested height ({:.2f} m) is higher than height of highest model level."
                                          .format(level_heights[i_hr, 0]))
                     v_req_alt[i_hr, :] = np.interp(heights_of_interest, level_heights[i_hr, ::-1],
-                                                   v_levels[i_hr, ::-1, row_in_v_levels, i_lon])
+                                                   v_levels[i_hr, ::-1, i_lat_in_subset, i_lon])
                     rho_req_alt[i_hr, :] = np.interp(heights_of_interest, level_heights[i_hr, ::-1],
                                                      density_levels[i_hr, ::-1])
                 p_req_alt = calc_power(v_req_alt, rho_req_alt)
@@ -236,30 +298,30 @@ def process_complete_grid(output_file):
                 # Determine wind statistics at fixed heights of interest.
                 for i_out, fixed_height_id in enumerate(analyzed_heights_ids['fixed']):
                     v_mean, v_perc5, v_perc32, v_perc50 = get_statistics(v_req_alt[:, fixed_height_id])
-                    res['fixed']['wind_speed']['mean'][i_out, i_lat, i_lon] = v_mean
-                    res['fixed']['wind_speed']['percentile'][5][i_out, i_lat, i_lon] = v_perc5
-                    res['fixed']['wind_speed']['percentile'][32][i_out, i_lat, i_lon] = v_perc32
-                    res['fixed']['wind_speed']['percentile'][50][i_out, i_lat, i_lon] = v_perc50
+                    res['fixed']['wind_speed']['mean'][i_out, i_lat_in_subset, i_lon] = v_mean
+                    res['fixed']['wind_speed']['percentile'][5][i_out, i_lat_in_subset, i_lon] = v_perc5
+                    res['fixed']['wind_speed']['percentile'][32][i_out, i_lat_in_subset, i_lon] = v_perc32
+                    res['fixed']['wind_speed']['percentile'][50][i_out, i_lat_in_subset, i_lon] = v_perc50
 
                     v_ranks = get_percentile_ranks(v_req_alt[:, fixed_height_id], [4., 8., 14., 25.])
-                    res['fixed']['wind_speed']['rank'][4][i_out, i_lat, i_lon] = v_ranks[0]
-                    res['fixed']['wind_speed']['rank'][8][i_out, i_lat, i_lon] = v_ranks[1]
-                    res['fixed']['wind_speed']['rank'][14][i_out, i_lat, i_lon] = v_ranks[2]
-                    res['fixed']['wind_speed']['rank'][25][i_out, i_lat, i_lon] = v_ranks[3]
+                    res['fixed']['wind_speed']['rank'][4][i_out, i_lat_in_subset, i_lon] = v_ranks[0]
+                    res['fixed']['wind_speed']['rank'][8][i_out, i_lat_in_subset, i_lon] = v_ranks[1]
+                    res['fixed']['wind_speed']['rank'][14][i_out, i_lat_in_subset, i_lon] = v_ranks[2]
+                    res['fixed']['wind_speed']['rank'][25][i_out, i_lat_in_subset, i_lon] = v_ranks[3]
 
                     p_fixed_height = p_req_alt[:, fixed_height_id]
 
                     p_mean, p_perc5, p_perc32, p_perc50 = get_statistics(p_fixed_height)
-                    res['fixed']['wind_power_density']['mean'][i_out, i_lat, i_lon] = p_mean
-                    res['fixed']['wind_power_density']['percentile'][5][i_out, i_lat, i_lon] = p_perc5
-                    res['fixed']['wind_power_density']['percentile'][32][i_out, i_lat, i_lon] = p_perc32
-                    res['fixed']['wind_power_density']['percentile'][50][i_out, i_lat, i_lon] = p_perc50
+                    res['fixed']['wind_power_density']['mean'][i_out, i_lat_in_subset, i_lon] = p_mean
+                    res['fixed']['wind_power_density']['percentile'][5][i_out, i_lat_in_subset, i_lon] = p_perc5
+                    res['fixed']['wind_power_density']['percentile'][32][i_out, i_lat_in_subset, i_lon] = p_perc32
+                    res['fixed']['wind_power_density']['percentile'][50][i_out, i_lat_in_subset, i_lon] = p_perc50
 
                     p_ranks = get_percentile_ranks(p_fixed_height, [40., 300., 1600., 9000.])
-                    res['fixed']['wind_power_density']['rank'][40][i_out, i_lat, i_lon] = p_ranks[0]
-                    res['fixed']['wind_power_density']['rank'][300][i_out, i_lat, i_lon] = p_ranks[1]
-                    res['fixed']['wind_power_density']['rank'][1600][i_out, i_lat, i_lon] = p_ranks[2]
-                    res['fixed']['wind_power_density']['rank'][9000][i_out, i_lat, i_lon] = p_ranks[3]
+                    res['fixed']['wind_power_density']['rank'][40][i_out, i_lat_in_subset, i_lon] = p_ranks[0]
+                    res['fixed']['wind_power_density']['rank'][300][i_out, i_lat_in_subset, i_lon] = p_ranks[1]
+                    res['fixed']['wind_power_density']['rank'][1600][i_out, i_lat_in_subset, i_lon] = p_ranks[2]
+                    res['fixed']['wind_power_density']['rank'][9000][i_out, i_lat_in_subset, i_lon] = p_ranks[3]
 
                 # Integrate power along the altitude.
                 for range_id in integration_range_ids:
@@ -272,7 +334,7 @@ def process_complete_grid(output_file):
                         y = p_req_alt[i_hr, height_id_start:height_id_final+1]
                         p_integral.append(-np.trapz(y, x))
 
-                    res['integration_ranges']['wind_power_density']['mean'][range_id, i_lat, i_lon] = np.mean(p_integral)
+                    res['integration_ranges']['wind_power_density']['mean'][range_id, i_lat_in_subset, i_lon] = np.mean(p_integral)
 
                 # Determine wind statistics for ceiling cases.
                 for i_out, ceiling_id in enumerate(analyzed_heights_ids['ceilings']):
@@ -286,38 +348,40 @@ def process_complete_grid(output_file):
                     p_ceiling = calc_power(v_ceiling, rho_ceiling)
 
                     v_mean, v_perc5, v_perc32, v_perc50 = get_statistics(v_ceiling)
-                    res['ceilings']['wind_speed']['mean'][i_out, i_lat, i_lon] = v_mean
-                    res['ceilings']['wind_speed']['percentile'][5][i_out, i_lat, i_lon] = v_perc5
-                    res['ceilings']['wind_speed']['percentile'][32][i_out, i_lat, i_lon] = v_perc32
-                    res['ceilings']['wind_speed']['percentile'][50][i_out, i_lat, i_lon] = v_perc50
+                    res['ceilings']['wind_speed']['mean'][i_out, i_lat_in_subset, i_lon] = v_mean
+                    res['ceilings']['wind_speed']['percentile'][5][i_out, i_lat_in_subset, i_lon] = v_perc5
+                    res['ceilings']['wind_speed']['percentile'][32][i_out, i_lat_in_subset, i_lon] = v_perc32
+                    res['ceilings']['wind_speed']['percentile'][50][i_out, i_lat_in_subset, i_lon] = v_perc50
 
                     v_ranks = get_percentile_ranks(v_ceiling, [4., 8., 14., 25.])
-                    res['ceilings']['wind_speed']['rank'][4][i_out, i_lat, i_lon] = v_ranks[0]
-                    res['ceilings']['wind_speed']['rank'][8][i_out, i_lat, i_lon] = v_ranks[1]
-                    res['ceilings']['wind_speed']['rank'][14][i_out, i_lat, i_lon] = v_ranks[2]
-                    res['ceilings']['wind_speed']['rank'][25][i_out, i_lat, i_lon] = v_ranks[3]
+                    res['ceilings']['wind_speed']['rank'][4][i_out, i_lat_in_subset, i_lon] = v_ranks[0]
+                    res['ceilings']['wind_speed']['rank'][8][i_out, i_lat_in_subset, i_lon] = v_ranks[1]
+                    res['ceilings']['wind_speed']['rank'][14][i_out, i_lat_in_subset, i_lon] = v_ranks[2]
+                    res['ceilings']['wind_speed']['rank'][25][i_out, i_lat_in_subset, i_lon] = v_ranks[3]
 
                     p_mean, p_perc5, p_perc32, p_perc50 = get_statistics(p_ceiling)
-                    res['ceilings']['wind_power_density']['mean'][i_out, i_lat, i_lon] = p_mean
-                    res['ceilings']['wind_power_density']['percentile'][5][i_out, i_lat, i_lon] = p_perc5
-                    res['ceilings']['wind_power_density']['percentile'][32][i_out, i_lat, i_lon] = p_perc32
-                    res['ceilings']['wind_power_density']['percentile'][50][i_out, i_lat, i_lon] = p_perc50
+                    res['ceilings']['wind_power_density']['mean'][i_out, i_lat_in_subset, i_lon] = p_mean
+                    res['ceilings']['wind_power_density']['percentile'][5][i_out, i_lat_in_subset, i_lon] = p_perc5
+                    res['ceilings']['wind_power_density']['percentile'][32][i_out, i_lat_in_subset, i_lon] = p_perc32
+                    res['ceilings']['wind_power_density']['percentile'][50][i_out, i_lat_in_subset, i_lon] = p_perc50
 
                     p_ranks = get_percentile_ranks(p_ceiling, [40., 300., 1600., 9000.])
-                    res['ceilings']['wind_power_density']['rank'][40][i_out, i_lat, i_lon] = p_ranks[0]
-                    res['ceilings']['wind_power_density']['rank'][300][i_out, i_lat, i_lon] = p_ranks[1]
-                    res['ceilings']['wind_power_density']['rank'][1600][i_out, i_lat, i_lon] = p_ranks[2]
-                    res['ceilings']['wind_power_density']['rank'][9000][i_out, i_lat, i_lon] = p_ranks[3]
+                    res['ceilings']['wind_power_density']['rank'][40][i_out, i_lat_in_subset, i_lon] = p_ranks[0]
+                    res['ceilings']['wind_power_density']['rank'][300][i_out, i_lat_in_subset, i_lon] = p_ranks[1]
+                    res['ceilings']['wind_power_density']['rank'][1600][i_out, i_lat_in_subset, i_lon] = p_ranks[2]
+                    res['ceilings']['wind_power_density']['rank'][9000][i_out, i_lat_in_subset, i_lon] = p_ranks[3]
 
-        print('Locations analyzed: ({}/{}).'.format(counter, total_iters))
+        print('Locations analyzed: ({}/{:.0f}).'.format(counter, total_iters)) 
         time_lapsed = float(timer()-start_time)
         time_remaining = time_lapsed/counter*(total_iters-counter)
         print("Time lapsed: {:.2f} hrs, expected time remaining: {:.2f} hrs.".format(time_lapsed/3600,
                                                                                      time_remaining/3600))
 
-    write_results_to_output_netcdf(output_variables, res)
+        write_results_to_output_netcdf(output_variables, res)
 
-    nc_out.close()  # Close the output NetCDF file.
+        nc_out.close()  # Close the output NetCDF file.
+
+
     ds.close()  # Close the input NetCDF file.
 
 
@@ -370,7 +434,7 @@ def write_results_to_output_netcdf(output_variables, result_arrays):
 
 def create_and_configure_output_netcdf(hours, lats, lons, output_file):
     # Write output to a new NetCDF file.
-    nc_out = Dataset(output_file, "w", format="NETCDF3_64BIT_OFFSET")
+    nc_out = Dataset(output_file, "w", format="NETCDF4")
     nc_out.createDimension("time", len(hours))
     nc_out.createDimension("latitude", len(lats))
     nc_out.createDimension("longitude", len(lons))
@@ -498,4 +562,30 @@ def eval_single_location(location_lat, location_lon, start_year, final_year):
 
 
 if __name__ == '__main__':
-    process_complete_grid(output_file_name)
+    print("processing monthly ERA5 data from the years {:d} to {:d}".format(start_year, final_year))
+
+    # Read command-line arguments
+    input_subset_ids = [] 
+    if len(sys.argv) > 1: #user input was given
+        help = """
+        python process_data.py -s subsetID      : process individual subset with ID subsetID
+        python process_data.py -s ID1 -e ID2    : process range of subsets starting at subset ID1 until ID2 (inclusively)
+        python process_data.py -h               : display this help
+        """
+        try:
+            opts, args = getopt.getopt(sys.argv[1:], "hs:e:", ["help", "start=", "end="])
+        except getopt.GetoptError:     # User input not given correctly, display help and end
+            print(help)
+            sys.exit()
+        for opt, arg in opts:
+            if opt in ("-h", "--help"):    # Help argument called, display help and end
+                print (help)
+                sys.exit()
+            elif opt in ("-s", "--start"):     # Specific subset by index selected  
+                input_subset_ids.append(int(arg))
+            elif opt in ("-e", "--end"):     # End of subset range indicated (inclusively) 
+                input_subset_ids.append(int(arg))
+        input_subset_ids.sort()
+
+    # Start processing
+    process_grid_subsets(output_file_name, input_subset_ids)

--- a/process_data.py
+++ b/process_data.py
@@ -164,7 +164,7 @@ def merge_output_files(start_year, final_year, max_subset_id):
 
     print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year, final_year, max_subset_id))
     nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
-    nc.to_netcdf((output_file_name.format(**{'start_year':start_year, 'final_year':final_year}))
+    nc.to_netcdf(output_file_name.format(**{'start_year':start_year, 'final_year':final_year}))
     
     return 0
 

--- a/process_data.py
+++ b/process_data.py
@@ -381,8 +381,8 @@ def process_grid_subsets(output_file, input_subset_ids):
         # Flatten output, convert to xarray Dataset and write to output file
         output_file_name = output_file.format(**{'start_year':start_year, 'final_year':final_year, 'lat_subset_id':i_subset, 'max_lat_subset_id':(n_subsets-1)})
         print('Writing output to file: {}'.format(output_file_name))
-        flattened_full_output = flatten_result_dict(lats_subset, lons, hours, res)
-        nc_out = xr.Dataset.from_dict(flattened_full_output)
+        flattened_subset_output = flatten_result_dict(lats_subset, lons, hours, res)
+        nc_out = xr.Dataset.from_dict(flattened_subset_output)
 
         nc_out.to_netcdf(output_file_name)
         nc_out.close()

--- a/process_data.py
+++ b/process_data.py
@@ -165,7 +165,6 @@ def merge_output_files(start_year, final_year, max_subset_id):
     print('All data for the years {} to {} is read from subset_files from 0 to {}'.format(start_year, final_year, max_subset_id))
     nc = xr.open_mfdataset(all_year_subset_files, concat_dim='latitude')
     nc.to_netcdf((output_file_name.format(**{'start_year':start_year, 'final_year':final_year}))
-    nc.close()
     
     return 0
 

--- a/process_data.py
+++ b/process_data.py
@@ -540,10 +540,9 @@ def eval_single_location(location_lat, location_lon, start_year, final_year):
     return hours, v_req_alt, v_ceilings, optimal_heights
 
 def interpret_input_args():
-    input_start_subset_id = 0 # Standard settings to process all subsets
-    input_end_subset_id = -1
     
-    if len(sys.argv) > 1: # User input was given, modify standard settings accordingly
+    if len(sys.argv) > 1: # User input was given
+        end_id_set = False
         help = """
         python process_data.py                  : process all latitude subsets
         python process_data.py -s subsetID      : process individual subset with ID subsetID
@@ -563,12 +562,15 @@ def interpret_input_args():
                 input_start_subset_id = int(arg)
             elif opt in ("-e", "--end"):     # Modified end of subset range indicated (inclusively) 
                 input_end_subset_id = int(arg)
-        if input_end_subset_id != -1:
-            if input_end_subset_id < input_start_subset_id:
+                end_id_set = True
+        if end_id_set and not input_end_subset_id == -1 and input_end_subset_id < input_start_subset_id:
                 raise ValueError("End subset id {} smaller than start id {}, check given input".format(
                               input_end_subset_id, input_start_subset_id))
-        else: # End ID not specified - process single subset with ID input_start_subset_id
+        elif not end_id_set: # End ID not specified - process single subset with ID input_start_subset_id
             input_end_subset_id = input_start_subset_id
+    else:
+        input_start_subset_id = 0 # Standard settings to process all subsets
+        input_end_subset_id = -1
             
     return input_start_subset_id, input_end_subset_id
 

--- a/utils.py
+++ b/utils.py
@@ -184,3 +184,21 @@ def compute_level_heights(levels, surface_pressure, levels_temperature, levels_h
             densities[i_hr, i_level] = pf/(r_d*levels_temperature[i_hr, i_level])
 
     return heights, densities
+
+
+def flatten_dict(input_dict, parent_key='', sep='.'):
+    """"Recursive function to convert multi-level dictionary to flat dictionary. 
+
+    Args: 
+        input_dict (dict): Dictionary to be flattened
+        parent_key (str): Key under which 'input_dict' is stored in the higher-level dictionary
+        sep (str): Separator used for joining together the keys pointing to the lower-level object.
+    """
+    items = []
+    for k, v in input_dict.items():
+        new_key = parent_key + sep + str(k).replace(" ", "") if parent_key else str(k).replace(" ", "")
+        if isinstance(v, dict):
+            items.extend(flatten_dict(v, new_key, sep=sep).items())
+        else: 
+            items.append((new_key, v))
+    return dict(items)


### PR DESCRIPTION
to have clearer history I tried to make this branch now work off of the first to-xarray branch..as it was not possible to separate the issues completely, lets see how this works
-  I see now that the commits of the to-xarray branch are also included here and the to-xarray pull request is referenced - so should I remove the other pull request? I guess that maybe I should have created this branch off of 'to-xarray' with some additional parameters to not include the commits..? Or is this completely right, as the code here is built upon the code from 'to-xarray'.  

implemented: 
subset-wise processing & writing output subset wise #4 
reading subsets-wise input in plotting
pre-formatted output_file_name in config  including placeholders (stil discussing with Mark about the best naming choices there)
switch to xarray (in plotting and also in writing the output file) #3 

to be resolved either before accepting the pull request or in a new issue: 
- output_file_name 'design' choices (e.g. whether to include the maximum number of subsets, as is done now)
- adding reverse compatibility in the plotting to already processed files (different file names, maybe only one file for all latitudes)
     + This is maybe a point to taken into consideration for the final output_file_name
- do we want (as is now) separate output files for each subset (even if all subsets are processed with one program call - so nothing is done in parallel) | these separate files are read in to plotting
    + maybe just add a small program to read all files and give out a single file again, similar to before -> then the plotting could read this and be reverse compatible without problems

  